### PR TITLE
[startOfNTimeAgo] Start/End of N Time Ago

### DIFF
--- a/parseplus.js
+++ b/parseplus.js
@@ -419,6 +419,21 @@
 					return date.startOf(monthyear);
 				}
 				return date.endOf(monthyear);
+				
+			}
+		})
+	    .addParser({
+	    	name: 'startOfNTimeAgo',
+  			template: "^(start|end) of ([\\d]+) ([_UNIT_]+) ago$",
+  			handler: function(match) {
+				var n = match[2];
+				var unit = match[3].toLowerCase();
+				var startOrEnd = match[1].toLowerCase();
+  				var date = moment().subtract(parseFloat(n), unit);
+				if(startOrEnd === 'start') {
+					return date.startOf(unit);
+				}
+				return date.endOf(unit);			
 			}
 		})
 	;


### PR DESCRIPTION
Creates a date starting/ending at some unit, basically `ago` with startOf/endOf

`moment().subtract(N, UNIT).startOf(UNIT)`:
- _start of 1 second ago_
- _start of 2 minutes ago_
- _start of 3 hours ago_
- _start of 4 days ago_
- _start of 5 months ago_
- _start of 6 years ago_

`moment().subtract(N, UNIT).endOf(UNIT)`:
- _end of 1 second ago_
- _end of 2 minutes ago_
- _end of 3 hours ago_
- _end of 4 days ago_
- _end of 5 months ago_
- _end of 6 years ago_